### PR TITLE
Add openrc cgroup + patches from Void

### DIFF
--- a/core-services/00-pseudofs.sh
+++ b/core-services/00-pseudofs.sh
@@ -11,5 +11,6 @@ mountpoint -q /dev/shm || mount -o mode=1777,nosuid,nodev -n -t tmpfs shm /dev/s
 
 if [ -z "$VIRTUALIZATION" ]; then
     mountpoint -q /sys/fs/cgroup || mount -o mode=0755 -t tmpfs cgroup /sys/fs/cgroup
+    mountpoint -q /sys/fs/cgroup/openrc || mkdir -p /sys/fs/cgroup/openrc && mount -t cgroup -o none,name=openrc cgroup /sys/fs/cgroup/openrc
     awk '$4 == 1 { system("mountpoint -q /sys/fs/cgroup/" $1 " || { mkdir -p /sys/fs/cgroup/" $1 " && mount -t cgroup -o " $1 " cgroup /sys/fs/cgroup/" $1 " ;}" ) }' /proc/cgroups
 fi

--- a/core-services/00-pseudofs.sh
+++ b/core-services/00-pseudofs.sh
@@ -8,6 +8,7 @@ mountpoint -q /dev || mount -o mode=0755,nosuid -t devtmpfs dev /dev
 mkdir -p -m0755 /run/runit /run/lvm /run/user /run/lock /run/log /dev/pts /dev/shm
 mountpoint -q /dev/pts || mount -o mode=0620,gid=5,nosuid,noexec -n -t devpts devpts /dev/pts
 mountpoint -q /dev/shm || mount -o mode=1777,nosuid,nodev -n -t tmpfs shm /dev/shm
+mountpoint -q /sys/kernel/security || mount -n -t securityfs securityfs /sys/kernel/security
 
 if [ -z "$VIRTUALIZATION" ]; then
     mountpoint -q /sys/fs/cgroup || mount -o mode=0755 -t tmpfs cgroup /sys/fs/cgroup

--- a/functions
+++ b/functions
@@ -49,7 +49,9 @@ deactivate_vgs() {
 deactivate_crypt() {
    if [ -x /sbin/dmsetup -o -x /bin/dmsetup ]; then
        msg "Deactivating Crypt Volumes"
-       dmsetup ls --target crypt --exec 'cryptsetup close'
+       for v in $(dmsetup ls --target crypt --exec "dmsetup info -c --noheadings -o open,name"); do
+           [ ${v%%:*} -eq 0 ] && cryptsetup close ${v##*:}
+       done
        deactivate_vgs "Crypt"
    fi
 }

--- a/services/agetty-tty1/conf
+++ b/services/agetty-tty1/conf
@@ -1,4 +1,4 @@
-if [ -x /sbin/agetty -o /bin/agetty ]; then
+if [ -x /sbin/agetty -o -x /bin/agetty ]; then
 	# util-linux specific settings
 	if [ "${tty}" = "tty1" ]; then
 		GETTY_ARGS="--noclear"


### PR DESCRIPTION
Included in this patch:

Artix-specific patches:

- Add openrc group
    This cgroup is created as a requirement by elogind.

Patches from Void:

- deactivate_crypt should not try to close encrypted volumes that are still mounted until shutdown
- fix an always succeeding test
- add a securityfs pseudofs for AppArmor et. al.