### PR TITLE
Add OpenRC support for managing services

### DIFF
--- a/1
+++ b/1
@@ -5,15 +5,26 @@ PATH=/usr/bin:/usr/sbin
 
 . /etc/runit/functions
 
-msg "Welcome to Artix Linux!"
+if [ -x /usr/bin/openrc ]; then
+  msg "Welcome to Artix Linux!"
 
-[ -r /etc/runit/rc.conf ] && . /etc/runit/rc.conf
+  # Start core services: we'll use OpenRC for this.
+  msg "Initializing services with OpenRC..."
+  
+  for runlevel in sysinit boot default; do
+       openrc $runlevel || msg_error "Failed to start $runlevel runlevel"
+  done
+else
+  msg "Welcome to Artix Linux!"
 
-# Start core services: one-time system tasks.
-detect_virt
-for f in /etc/runit/core-services/*.sh; do
-    [ -r $f ] && . $f
-done
+  [ -r /etc/runit/rc.conf ] && . /etc/runit/rc.conf
+
+  # Start core services: one-time system tasks.
+  detect_virt
+  for f in /etc/runit/core-services/*.sh; do
+      [ -r $f ] && . $f
+  done
+fi
 
 dmesg >/var/log/dmesg.log
 if [ $(sysctl -n kernel.dmesg_restrict 2>/dev/null) -eq 1 ]; then


### PR DESCRIPTION
While runit can be PID 1, OpenRC can play the role of service manager. This is good since runit has not many initscripts (in [their website](http://smarden.org/runit/runscripts.html) there are a few, but some are kinda outdated) and OpenRC is our main init system/service manager (IMO we should take advantage of OpenRC's compatibility with any /sbin/init program).

This patch will make runit look for openrc and, if it's available, it will use it to start services (however when shutting down the system, runit does well so openrc's shutdown runlevel is not necessary to invoke in 3).
 
In the case OpenRC is not available, runit will do the job, like before this patch