### PR TITLE
Various Runit changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ all:
 	$(CC) $(CFLAGS) pause.c -o pause $(LDFLAGS)
 
 install:
-	install -d ${DESTDIR}${PREFIX}/bin
-	install -m755 halt ${DESTDIR}${PREFIX}/bin/halt-runit
-	install -m755 pause ${DESTDIR}${PREFIX}/bin/pause-runit
-	install -m755 shutdown ${DESTDIR}${PREFIX}/bin/shutdown-runit
-	install -m755 modules-load ${DESTDIR}${PREFIX}/bin/modules-load
-	install -m755 zzz ${DESTDIR}${PREFIX}/bin/zzz-runit
-	ln -sf halt-runit ${DESTDIR}${PREFIX}/bin/poweroff-runit
-	ln -sf halt-runit ${DESTDIR}${PREFIX}/bin/reboot-runit
+	install -d ${DESTDIR}${PREFIX}/lib/runit-artix/bin
+	install -m755 halt ${DESTDIR}${PREFIX}/lib/runit-artix/bin/halt
+	install -m755 pause ${DESTDIR}${PREFIX}/lib/runit-artix/bin/pause
+	install -m755 shutdown ${DESTDIR}${PREFIX}/lib/runit-artix/bin/shutdown
+	install -m755 modules-load ${DESTDIR}${PREFIX}/lib/runit-artix/bin/modules-load
+	install -m755 zzz ${DESTDIR}${PREFIX}/lib/runit-artix/bin/zzz
+	ln -sf halt ${DESTDIR}${PREFIX}/lib/runit-artix/bin/poweroff
+	ln -sf halt ${DESTDIR}${PREFIX}/lib/runit-artix/bin/reboot
 	install -d ${DESTDIR}${PREFIX}/share/man/man1
 	install -m644 pause.1 ${DESTDIR}${PREFIX}/share/man/man1
 	install -d ${DESTDIR}${PREFIX}/share/man/man8

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ install:
 	install -m755 rc.shutdown ${DESTDIR}/etc/runit
 	ln -sf /run/runit/reboot ${DESTDIR}/etc/runit/
 	ln -sf /run/runit/stopit ${DESTDIR}/etc/runit/
-	cp -aP runsvdir/* ${DESTDIR}/etc/runit/runsvdir/
-	cp -aP services/* ${DESTDIR}/etc/runit/sv/
+	cp -R --no-dereference --preserve=mode,links -v runsvdir/* ${DESTDIR}/etc/runit/runsvdir/
+	cp -R --no-dereference --preserve=mode,links -v services/* ${DESTDIR}/etc/runit/sv/
 
 clean:
 	-rm -f halt pause

--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -19,3 +19,6 @@ if [ -n "$TIMEZONE" ]; then
     msg "Setting up timezone to '${TIMEZONE}'..."
     ln -sf "/usr/share/zoneinfo/$TIMEZONE" /etc/localtime
 fi
+
+msg "Setting up sysusers.d entries..."
+sysusers


### PR DESCRIPTION
Included:

Artix-only patch:
- Move runit binaries to a dedicated directory
This will reduce clutter in primary /bin directory and will make linking to the bin directory easier (in case we will have an `eselect`-like utility later) instead of appending `-runit` to every binary.

- Add opensysusers initscript compatibility
Since opensysusers is a one-shot-at-boot initscript, add them to /etc/runit/1 instead.

Patch imported from Void:

- Adjust options for cp command during install
  